### PR TITLE
fix: ignore .agc state in workspace guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The harness creates and manages this layout:
 
 `state/` is reserved for transient harness runtime files such as Codex output scratch directories.
 
-To keep arbitrary repositories clean, the CLI adds `/.agc/` to Git's per-repository exclude file, resolved via `git rev-parse --git-path info/exclude`, and does not mutate tracked `.gitignore` files. That means `.agc/` stays untracked by default, while still living at a predictable repository-local path. The workflow also treats pre-existing `.agc/` files as harness-owned state during cleanliness checks, so stale local harness state does not block a run before the exclude entry is refreshed. If a repository intentionally wants to commit `.agc/`, it can remove that exclude entry and manage ignore rules itself.
+The harness does not modify `.gitignore`, `.git/info/exclude`, or any other Git ignore settings for `.agc/`. Repositories decide for themselves whether `.agc/` should be committed, ignored, or left as an explicit local change.
 
 ## Workflow
 
@@ -117,22 +117,21 @@ Given a single prompt argument, the CLI runs this sequence:
 1. Resolve the current repository root with `git rev-parse --show-toplevel`.
 2. Read the current branch with `git rev-parse --abbrev-ref HEAD`.
 3. Refuse to continue unless the branch is `main` or `master`.
-4. Refuse to continue unless `git status --porcelain` shows no changes outside `.agc/`.
-5. Resolve Git's per-repository exclude file with `git rev-parse --git-path info/exclude`.
-6. Ensure `.agc/` exists, create `.agc/config.json` if missing, and add `/.agc/` to that exclude file.
-7. Ask Codex for a feature-branch name using `codex exec` in read-only mode.
-8. Fall back to a deterministic slugged branch name if Codex fails or returns invalid output.
-9. Create the branch from the current base branch with `git checkout -b <branch> <base>`.
-10. Invoke `codex exec` non-interactively to implement the user request.
-11. If no files changed, stop cleanly without committing or opening a PR.
-12. If files changed, stage everything with `git add --all`.
-13. Ask Codex for a one-line commit message and fall back to a deterministic conventional message if needed.
-14. Commit and push the branch.
-15. Ask Codex for a PR title/body and fall back to a deterministic template if needed.
-16. Open the PR with `gh pr create --base ... --head ... --title ... --body ...`.
-17. Resolve PR metadata with `gh pr view <branch> --json ...`.
-18. Request the configured reviewers with `gh pr edit <number> --add-reviewer <reviewer1,reviewer2>`.
-19. Enter the review loop.
+4. Refuse to continue unless `git status --porcelain` is empty.
+5. Ensure `.agc/` exists and create `.agc/config.json` if missing.
+6. Ask Codex for a feature-branch name using `codex exec` in read-only mode.
+7. Fall back to a deterministic slugged branch name if Codex fails or returns invalid output.
+8. Create the branch from the current base branch with `git checkout -b <branch> <base>`.
+9. Invoke `codex exec` non-interactively to implement the user request.
+10. If no files changed, stop cleanly without committing or opening a PR.
+11. If files changed, stage everything with `git add --all`.
+12. Ask Codex for a one-line commit message and fall back to a deterministic conventional message if needed.
+13. Commit and push the branch.
+14. Ask Codex for a PR title/body and fall back to a deterministic template if needed.
+15. Open the PR with `gh pr create --base ... --head ... --title ... --body ...`.
+16. Resolve PR metadata with `gh pr view <branch> --json ...`.
+17. Request the configured reviewers with `gh pr edit <number> --add-reviewer <reviewer1,reviewer2>`.
+18. Enter the review loop.
 
 ## Review Loop
 
@@ -171,7 +170,7 @@ If Codex helper calls fail for those bounded text tasks, the workflow still proc
 The CLI exits non-zero when:
 
 - the current branch is not `main` or `master`
-- the workspace is dirty before the run starts, excluding harness-owned `.agc/` state
+- the workspace is dirty before the run starts
 - `git`, `gh`, or `codex` commands fail
 - `.agc/config.json` is invalid
 - branch creation fails

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,36 +1,5 @@
-import { isAbsolute, resolve } from "node:path";
 import { AppError } from "./errors";
 import type { ShellRunner } from "./types";
-
-const HARNESS_ROOT = ".agc";
-
-function normalizeStatusPath(path: string): string {
-  return path.trim().replace(/^"+|"+$/g, "");
-}
-
-function isHarnessPath(path: string): boolean {
-  const normalized = normalizeStatusPath(path);
-  return (
-    normalized === HARNESS_ROOT || normalized.startsWith(`${HARNESS_ROOT}/`)
-  );
-}
-
-function hasNonHarnessChanges(stdout: string): boolean {
-  return stdout
-    .split(/\r?\n/)
-    .map((entry) => entry.trimEnd())
-    .filter((entry) => entry.length > 0)
-    .some((entry) => {
-      const paths = entry
-        .slice(3)
-        .trim()
-        .split(" -> ")
-        .map((path) => path.trim())
-        .filter((path) => path.length > 0);
-
-      return paths.some((path) => !isHarnessPath(path));
-    });
-}
 
 export class GitClient {
   constructor(private readonly shell: ShellRunner) {}
@@ -53,24 +22,13 @@ export class GitClient {
     return result.stdout.trim();
   }
 
-  async getGitPath(cwd: string, path: string): Promise<string> {
-    const result = await this.shell.run({
-      args: ["git", "rev-parse", "--git-path", path],
-      cwd,
-    });
-
-    const resolvedPath = result.stdout.trim();
-
-    return isAbsolute(resolvedPath) ? resolvedPath : resolve(cwd, resolvedPath);
-  }
-
   async ensureCleanWorkspace(cwd: string): Promise<void> {
     const result = await this.shell.run({
       args: ["git", "status", "--porcelain"],
       cwd,
     });
 
-    if (hasNonHarnessChanges(result.stdout)) {
+    if (result.stdout.trim().length > 0) {
       throw new AppError("Workspace must be clean before running this CLI.");
     }
   }
@@ -99,7 +57,7 @@ export class GitClient {
       cwd,
     });
 
-    return hasNonHarnessChanges(result.stdout);
+    return result.stdout.trim().length > 0;
   }
 
   async stageAll(cwd: string): Promise<void> {

--- a/src/harness.test.ts
+++ b/src/harness.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, test } from "bun:test";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { AppError } from "./errors";
@@ -18,16 +18,14 @@ afterEach(async () => {
 async function createRepositoryRoot(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "agc-harness-test-"));
   temporaryDirectories.push(root);
-  await mkdir(join(root, ".git", "info"), { recursive: true });
   return root;
 }
 
-test("creates a default .agc layout and ignores it via git exclude", async () => {
+test("creates a default .agc layout", async () => {
   const repoRoot = await createRepositoryRoot();
   const workspace = new FileSystemHarnessWorkspace();
-  const gitExcludeFile = join(repoRoot, ".git", "info", "exclude");
 
-  const state = await workspace.ensure(repoRoot, gitExcludeFile);
+  const state = await workspace.ensure(repoRoot);
 
   expect(state.rootDir).toBe(join(repoRoot, ".agc"));
   expect(state.stateDir).toBe(join(repoRoot, ".agc", "state"));
@@ -35,36 +33,31 @@ test("creates a default .agc layout and ignores it via git exclude", async () =>
   expect(JSON.parse(await readFile(state.configFile, "utf8"))).toEqual({
     pullRequestReviewers: ["@copilot"],
   });
-  expect(await readFile(gitExcludeFile, "utf8")).toContain("/.agc/");
 });
 
 test("reuses existing .agc reviewer configuration", async () => {
   const repoRoot = await createRepositoryRoot();
   const workspace = new FileSystemHarnessWorkspace();
   const configFile = join(repoRoot, ".agc", "config.json");
-  const gitExcludeFile = join(repoRoot, ".git", "info", "exclude");
 
   await mkdir(join(repoRoot, ".agc"), { recursive: true });
   await Bun.write(
     configFile,
     `${JSON.stringify({ pullRequestReviewers: ["@review-bot", "@copilot"] }, null, 2)}\n`,
   );
-  await writeFile(gitExcludeFile, "*.log\n", "utf8");
 
-  const state = await workspace.ensure(repoRoot, gitExcludeFile);
+  const state = await workspace.ensure(repoRoot);
 
   expect(state.config.pullRequestReviewers).toEqual([
     "@review-bot",
     "@copilot",
   ]);
-  expect(await readFile(gitExcludeFile, "utf8")).toContain("/.agc/");
 });
 
 test("rejects non-string reviewer values in .agc config", async () => {
   const repoRoot = await createRepositoryRoot();
   const workspace = new FileSystemHarnessWorkspace();
   const configFile = join(repoRoot, ".agc", "config.json");
-  const gitExcludeFile = join(repoRoot, ".git", "info", "exclude");
 
   await mkdir(join(repoRoot, ".agc"), { recursive: true });
   await Bun.write(
@@ -72,7 +65,7 @@ test("rejects non-string reviewer values in .agc config", async () => {
     `${JSON.stringify({ pullRequestReviewers: ["@copilot", { login: "@review-bot" }] }, null, 2)}\n`,
   );
 
-  await expect(workspace.ensure(repoRoot, gitExcludeFile)).rejects.toThrow(
+  await expect(workspace.ensure(repoRoot)).rejects.toThrow(
     /Invalid \.agc\/config\.json:.*expected string, received object/s,
   );
 });
@@ -81,7 +74,6 @@ test("rejects blank reviewer values in .agc config", async () => {
   const repoRoot = await createRepositoryRoot();
   const workspace = new FileSystemHarnessWorkspace();
   const configFile = join(repoRoot, ".agc", "config.json");
-  const gitExcludeFile = join(repoRoot, ".git", "info", "exclude");
 
   await mkdir(join(repoRoot, ".agc"), { recursive: true });
   await Bun.write(
@@ -89,7 +81,7 @@ test("rejects blank reviewer values in .agc config", async () => {
     `${JSON.stringify({ pullRequestReviewers: ["   "] }, null, 2)}\n`,
   );
 
-  await expect(workspace.ensure(repoRoot, gitExcludeFile)).rejects.toThrow(
+  await expect(workspace.ensure(repoRoot)).rejects.toThrow(
     /Invalid \.agc\/config\.json:.*Too small: expected string to have >=1 characters/s,
   );
 });

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -1,5 +1,5 @@
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { z } from "zod";
 import { AppError } from "./errors";
 import type { HarnessConfig } from "./types";
@@ -11,7 +11,6 @@ export interface HarnessLayout {
 }
 
 export interface HarnessWorkspaceState extends HarnessLayout {
-  gitExcludeFile: string;
   config: HarnessConfig;
 }
 
@@ -19,7 +18,6 @@ const DEFAULT_CONFIG: HarnessConfig = {
   pullRequestReviewers: ["@copilot"],
 };
 
-const AGC_EXCLUDE_ENTRY = "/.agc/";
 const harnessConfigSchema = z.object({
   pullRequestReviewers: z.array(z.string().trim().min(1)).min(1),
 });
@@ -50,27 +48,6 @@ function normalizeConfig(value: unknown): HarnessConfig {
   return {
     pullRequestReviewers: [...new Set(parsed.data.pullRequestReviewers)],
   };
-}
-
-async function ensureGitExcludeEntry(path: string): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-
-  const current = await readFile(path, "utf8").catch(() => "");
-  const entries = current
-    .split(/\r?\n/)
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0);
-
-  if (entries.includes(AGC_EXCLUDE_ENTRY)) {
-    return;
-  }
-
-  const next =
-    current.endsWith("\n") || current.length === 0
-      ? `${current}${AGC_EXCLUDE_ENTRY}\n`
-      : `${current}\n${AGC_EXCLUDE_ENTRY}\n`;
-
-  await writeFile(path, next, "utf8");
 }
 
 async function ensureConfigFile(path: string): Promise<HarnessConfig> {
@@ -106,19 +83,14 @@ export async function createHarnessTempDirectory(
 }
 
 export class FileSystemHarnessWorkspace {
-  async ensure(
-    repoRoot: string,
-    gitExcludeFile: string,
-  ): Promise<HarnessWorkspaceState> {
+  async ensure(repoRoot: string): Promise<HarnessWorkspaceState> {
     const layout = defaultLayout(repoRoot);
 
     await mkdir(layout.stateDir, { recursive: true });
-    await ensureGitExcludeEntry(gitExcludeFile);
     const config = await ensureConfigFile(layout.configFile);
 
     return {
       ...layout,
-      gitExcludeFile,
       config,
     };
   }

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -126,13 +126,10 @@ class TestLogger implements Logger {
 }
 
 function stubHarness(reviewers: string[] = ["@copilot"]): {
-  ensure: (
-    repoRoot: string,
-    gitExcludeFile: string,
-  ) => Promise<HarnessWorkspaceState>;
+  ensure: (repoRoot: string) => Promise<HarnessWorkspaceState>;
 } {
   return {
-    ensure: async (repoRoot: string, gitExcludeFile: string) => {
+    ensure: async (repoRoot: string) => {
       const stateDir = await mkdtemp(join(tmpdir(), "agc-workflow-tests-"));
       temporaryDirectories.push(stateDir);
 
@@ -140,7 +137,6 @@ function stubHarness(reviewers: string[] = ["@copilot"]): {
         rootDir: join(repoRoot, ".agc"),
         stateDir,
         configFile: join(repoRoot, ".agc", "config.json"),
-        gitExcludeFile,
         config: {
           pullRequestReviewers: reviewers,
         },
@@ -175,12 +171,9 @@ describe("workflow guards", () => {
         shell,
         logger: new TestLogger(),
         harness: {
-          ensure: async () => {
+          ensure: async (repoRoot: string) => {
             harnessEnsureCalls += 1;
-            return await stubHarness().ensure(
-              "/repo",
-              "/repo/.git/info/exclude",
-            );
+            return await stubHarness().ensure(repoRoot);
           },
         },
         sleep: async () => undefined,
@@ -218,7 +211,7 @@ describe("workflow guards", () => {
     shell.assertComplete();
   });
 
-  test("ignores existing .agc files when evaluating workspace cleanliness", async () => {
+  test("fails on existing .agc files when the user has not ignored them", async () => {
     const shell = new SequenceShellRunner([
       exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
       exact(["git", "rev-parse", "--abbrev-ref", "HEAD"], result("main\n")),
@@ -226,30 +219,19 @@ describe("workflow guards", () => {
         ["git", "status", "--porcelain"],
         result("?? .agc/config.json\n?? .agc/state/session.log\n"),
       ),
-      exact(
-        ["git", "rev-parse", "--git-path", "info/exclude"],
-        result("/repo/.git/info/exclude\n"),
-      ),
-      codexOutputContains("Return only a git branch name.", "feature/no-op\n"),
-      exact(["git", "check-ref-format", "--branch", "feature/no-op"], result()),
-      exact(["git", "checkout", "-b", "feature/no-op", "main"], result()),
-      codexEditContains("Implement the requested change in this repository."),
-      exact(
-        ["git", "status", "--porcelain"],
-        result("?? .agc/state/session.log\n"),
-      ),
-      exact(["git", "checkout", "main"], result()),
     ]);
 
-    const workflow = await runPromptWorkflow("No-op request", {
-      shell,
-      logger: new TestLogger(),
-      harness: stubHarness(),
-      sleep: async () => undefined,
-    });
+    await expect(
+      runPromptWorkflow("No-op request", {
+        shell,
+        logger: new TestLogger(),
+        harness: stubHarness(),
+        sleep: async () => undefined,
+      }),
+    ).rejects.toThrow(
+      new AppError("Workspace must be clean before running this CLI."),
+    );
 
-    expect(workflow.committed).toBe(false);
-    expect(workflow.reviewLoopReason).toBe("no_initial_changes");
     shell.assertComplete();
   });
 });
@@ -276,10 +258,6 @@ test("skips commit and PR creation when codex makes no changes", async () => {
     exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
     exact(["git", "rev-parse", "--abbrev-ref", "HEAD"], result("main\n")),
     exact(["git", "status", "--porcelain"], result("")),
-    exact(
-      ["git", "rev-parse", "--git-path", "info/exclude"],
-      result("/repo/.git/info/exclude\n"),
-    ),
     codexOutputContains("Return only a git branch name.", "feature/no-op\n"),
     exact(["git", "check-ref-format", "--branch", "feature/no-op"], result()),
     exact(["git", "checkout", "-b", "feature/no-op", "main"], result()),
@@ -317,10 +295,6 @@ test("review loop terminates when review fixes produce no file changes", async (
     exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
     exact(["git", "rev-parse", "--abbrev-ref", "HEAD"], result("main\n")),
     exact(["git", "status", "--porcelain"], result("")),
-    exact(
-      ["git", "rev-parse", "--git-path", "info/exclude"],
-      result("/repo/.git/info/exclude\n"),
-    ),
     codexOutputContains(
       "Return only a git branch name.",
       "feature/review-pass\n",
@@ -438,10 +412,6 @@ test("review loop respects max unproductive polls before exiting", async () => {
     exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
     exact(["git", "rev-parse", "--abbrev-ref", "HEAD"], result("main\n")),
     exact(["git", "status", "--porcelain"], result("")),
-    exact(
-      ["git", "rev-parse", "--git-path", "info/exclude"],
-      result("/repo/.git/info/exclude\n"),
-    ),
     codexOutputContains(
       "Return only a git branch name.",
       "feature/review-wait\n",
@@ -560,10 +530,6 @@ test("handles only new actionable review comments and re-requests review after p
     exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
     exact(["git", "rev-parse", "--abbrev-ref", "HEAD"], result("main\n")),
     exact(["git", "status", "--porcelain"], result("")),
-    exact(
-      ["git", "rev-parse", "--git-path", "info/exclude"],
-      result("/repo/.git/info/exclude\n"),
-    ),
     codexOutputContains(
       "Return only a git branch name.",
       "feature/review-loop\n",

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -22,10 +22,7 @@ export interface WorkflowDependencies {
   shell: ShellRunner;
   logger: Logger;
   harness?: {
-    ensure(
-      repoRoot: string,
-      gitExcludeFile: string,
-    ): Promise<HarnessWorkspaceState>;
+    ensure(repoRoot: string): Promise<HarnessWorkspaceState>;
   };
   sleep?: (ms: number) => Promise<void>;
   reviewPollIntervalMs?: number;
@@ -68,15 +65,13 @@ export async function runPromptWorkflow(
   }
 
   await git.ensureCleanWorkspace(repoRoot);
-  const gitExcludeFile = await git.getGitPath(repoRoot, "info/exclude");
-  const harnessState = await harness.ensure(repoRoot, gitExcludeFile);
+  const harnessState = await harness.ensure(repoRoot);
 
   logger.info("workflow.start", {
     repoRoot,
     baseBranch,
     agcDir: harnessState.rootDir,
     reviewers: harnessState.config.pullRequestReviewers.join(","),
-    gitExcludeFile: harnessState.gitExcludeFile,
   });
 
   const branch = await codex.generateBranchName(


### PR DESCRIPTION
## Summary
- ignore harness-owned \.agc state when evaluating clean-workspace guards
- keep branch and real dirty-worktree guard failures side-effect free before bootstrap
- document the behavior and add workflow coverage for existing \.agc state

Closes #11

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops managing `.agc/` Git ignore settings and keeps pre‑bootstrap guard failures side‑effect free. Repos now choose whether to ignore or commit `.agc/` (closes #11).

- **Bug Fixes**
  - Removes automatic `/.agc/` ignore management and the `git rev-parse --git-path info/exclude` step.
  - Defers `harness.ensure` until after `git status --porcelain` checks to avoid side effects.
  - Updates README and tests; adds a guard test that fails when `.agc/` files are unignored.

<sup>Written for commit a6e06d0e8fb252dd1ca5389c0c14131a7e466564. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Workspace cleanliness checks now ignore changes within the harness directory (`.agc/`), allowing development work to proceed unblocked even when harness-owned state exists locally.

**Documentation**
- Updated documentation clarifying workspace state requirements during pre-run validation and revised major failure conditions to reflect the updated cleanliness gate behavior that tolerates harness-directory changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->