### PR TITLE
fix: exclude .agc from workflow git state

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,15 @@ The harness creates and manages this layout:
 
 `state/` is reserved for transient harness runtime files such as Codex output scratch directories.
 
-The harness does not manage Git ignore rules for `.agc/`. That directory is repository-local on purpose, and users can choose whether to commit it or ignore it. For most repositories, adding `.agc/` to `.gitignore` is strongly recommended; otherwise `.agc/config.json` and transient files under `.agc/state/` can be picked up by the workflow's `git add --all` step and committed to the PR branch.
+The harness does not manage Git ignore rules for `.agc/`. That directory is repository-local on purpose, and users can choose whether to commit it or ignore it.
+
+The automated workflow treats `.agc/` as harness-owned state:
+
+- preflight clean-workspace checks ignore `.agc/`
+- no-op detection ignores `.agc/`
+- the workflow's `git add --all` step excludes `.agc/`
+
+That keeps first-run bootstrap and existing local harness state from blocking normal runs or being swept into automated PR commits. If a repository wants to track `.agc/config.json`, commit that file deliberately outside the automated workflow.
 
 If a repository wants to track `.agc/config.json` but keep runtime scratch files out of version control, prefer an ignore pattern like:
 
@@ -123,14 +131,14 @@ Given a single prompt argument, the CLI runs this sequence:
 1. Resolve the current repository root with `git rev-parse --show-toplevel`.
 2. Read the current branch with `git rev-parse --abbrev-ref HEAD`.
 3. Refuse to continue unless the branch is `main` or `master`.
-4. Refuse to continue unless `git status --porcelain` is empty.
+4. Refuse to continue unless `git status --porcelain -- . ':(exclude).agc'` is empty.
 5. Ensure `.agc/` exists and create `.agc/config.json` if missing.
 6. Ask Codex for a feature-branch name using `codex exec` in read-only mode.
 7. Fall back to a deterministic slugged branch name if Codex fails or returns invalid output.
 8. Create the branch from the current base branch with `git checkout -b <branch> <base>`.
 9. Invoke `codex exec` non-interactively to implement the user request.
-10. If no files changed, stop cleanly without committing or opening a PR.
-11. If files changed, stage everything with `git add --all`.
+10. If no files changed outside `.agc/`, stop cleanly without committing or opening a PR.
+11. If files changed, stage repository changes with `git add --all -- . ':(exclude).agc'`.
 12. Ask Codex for a one-line commit message and fall back to a deterministic conventional message if needed.
 13. Commit and push the branch.
 14. Ask Codex for a PR title/body and fall back to a deterministic template if needed.

--- a/src/git.ts
+++ b/src/git.ts
@@ -2,6 +2,20 @@ import { isAbsolute, resolve } from "node:path";
 import { AppError } from "./errors";
 import type { ShellRunner } from "./types";
 
+const HARNESS_GIT_PATHS = [".agc"];
+
+function withExcludedPaths(
+  baseArgs: string[],
+  excludedPaths: string[],
+): string[] {
+  return [
+    ...baseArgs,
+    "--",
+    ".",
+    ...excludedPaths.map((path) => `:(exclude)${path}`),
+  ];
+}
+
 export class GitClient {
   constructor(private readonly shell: ShellRunner) {}
 
@@ -36,7 +50,10 @@ export class GitClient {
 
   async ensureCleanWorkspace(cwd: string): Promise<void> {
     const result = await this.shell.run({
-      args: ["git", "status", "--porcelain"],
+      args: withExcludedPaths(
+        ["git", "status", "--porcelain"],
+        HARNESS_GIT_PATHS,
+      ),
       cwd,
     });
 
@@ -65,7 +82,10 @@ export class GitClient {
 
   async hasChanges(cwd: string): Promise<boolean> {
     const result = await this.shell.run({
-      args: ["git", "status", "--porcelain"],
+      args: withExcludedPaths(
+        ["git", "status", "--porcelain"],
+        HARNESS_GIT_PATHS,
+      ),
       cwd,
     });
 
@@ -74,7 +94,7 @@ export class GitClient {
 
   async stageAll(cwd: string): Promise<void> {
     await this.shell.run({
-      args: ["git", "add", "--all"],
+      args: withExcludedPaths(["git", "add", "--all"], HARNESS_GIT_PATHS),
       cwd,
     });
   }

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -13,6 +13,22 @@ import { runPromptWorkflow } from "./workflow";
 const testFileDirectory = dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = resolve(testFileDirectory, "..");
 const temporaryDirectories: string[] = [];
+const gitStatusExcludingHarness = [
+  "git",
+  "status",
+  "--porcelain",
+  "--",
+  ".",
+  ":(exclude).agc",
+];
+const gitAddExcludingHarness = [
+  "git",
+  "add",
+  "--all",
+  "--",
+  ".",
+  ":(exclude).agc",
+];
 
 interface Step {
   match(args: string[]): boolean;
@@ -162,7 +178,7 @@ describe("workflow guards", () => {
     const shell = new SequenceShellRunner([
       exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
       exact(["git", "rev-parse", "--abbrev-ref", "HEAD"], result("main\n")),
-      exact(["git", "status", "--porcelain"], result(" M README.md\n")),
+      exact(gitStatusExcludingHarness, result(" M README.md\n")),
     ]);
 
     await expect(
@@ -203,6 +219,31 @@ describe("workflow guards", () => {
 
     shell.assertComplete();
   });
+
+  test("ignores harness-owned .agc changes during workspace guard and no-op detection", async () => {
+    const shell = new SequenceShellRunner([
+      exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
+      exact(["git", "rev-parse", "--abbrev-ref", "HEAD"], result("main\n")),
+      exact(gitStatusExcludingHarness, result("")),
+      codexOutputContains("Return only a git branch name.", "feature/no-op\n"),
+      exact(["git", "check-ref-format", "--branch", "feature/no-op"], result()),
+      exact(["git", "checkout", "-b", "feature/no-op", "main"], result()),
+      codexEditContains("Implement the requested change in this repository."),
+      exact(gitStatusExcludingHarness, result("")),
+      exact(["git", "checkout", "main"], result()),
+    ]);
+
+    const workflow = await runPromptWorkflow("No-op request", {
+      shell,
+      logger: new TestLogger(),
+      harness: stubHarness(),
+      sleep: async () => undefined,
+    });
+
+    expect(workflow.committed).toBe(false);
+    expect(workflow.reviewLoopReason).toBe("no_initial_changes");
+    shell.assertComplete();
+  });
 });
 
 test("feature branch naming falls back deterministically", async () => {
@@ -226,12 +267,12 @@ test("skips commit and PR creation when codex makes no changes", async () => {
   const shell = new SequenceShellRunner([
     exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
     exact(["git", "rev-parse", "--abbrev-ref", "HEAD"], result("main\n")),
-    exact(["git", "status", "--porcelain"], result("")),
+    exact(gitStatusExcludingHarness, result("")),
     codexOutputContains("Return only a git branch name.", "feature/no-op\n"),
     exact(["git", "check-ref-format", "--branch", "feature/no-op"], result()),
     exact(["git", "checkout", "-b", "feature/no-op", "main"], result()),
     codexEditContains("Implement the requested change in this repository."),
-    exact(["git", "status", "--porcelain"], result("")),
+    exact(gitStatusExcludingHarness, result("")),
     exact(["git", "checkout", "main"], result()),
   ]);
   const logger = new TestLogger();
@@ -259,11 +300,91 @@ test("skips commit and PR creation when codex makes no changes", async () => {
   shell.assertComplete();
 });
 
+test("stages repository changes while excluding harness-owned .agc paths", async () => {
+  const shell = new SequenceShellRunner([
+    exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
+    exact(["git", "rev-parse", "--abbrev-ref", "HEAD"], result("main\n")),
+    exact(gitStatusExcludingHarness, result("")),
+    codexOutputContains("Return only a git branch name.", "feature/docs\n"),
+    exact(["git", "check-ref-format", "--branch", "feature/docs"], result()),
+    exact(["git", "checkout", "-b", "feature/docs", "main"], result()),
+    codexEditContains("Implement the requested change in this repository."),
+    exact(gitStatusExcludingHarness, result(" M README.md\n")),
+    exact(gitAddExcludingHarness, result()),
+    exact(["git", "diff", "--cached", "--stat"], result(" README.md | 2 +-\n")),
+    codexOutputContains(
+      "Return only a single conventional commit message line.",
+      "docs: update readme\n",
+    ),
+    exact(["git", "commit", "-m", "docs: update readme"], result()),
+    exact(["git", "push", "-u", "origin", "feature/docs"], result()),
+    exact(
+      ["git", "diff", "main...HEAD", "--stat"],
+      result(" README.md | 2 +-\n"),
+    ),
+    codexOutputContains(
+      "Draft a GitHub pull request title and body.",
+      "TITLE: docs: update readme\nBODY:\nSummary\n",
+    ),
+    exact(
+      [
+        "gh",
+        "pr",
+        "create",
+        "--base",
+        "main",
+        "--head",
+        "feature/docs",
+        "--title",
+        "docs: update readme",
+        "--body",
+        "Summary",
+      ],
+      result(),
+    ),
+    exact(
+      [
+        "gh",
+        "pr",
+        "view",
+        "feature/docs",
+        "--json",
+        "number,url,title,body,headRefName,baseRefName",
+      ],
+      result(
+        '{"number":12,"url":"https://example.com/pr/12","headRefName":"feature/docs","baseRefName":"main","title":"docs: update readme","body":"Summary"}\n',
+      ),
+    ),
+    exact(["gh", "pr", "edit", "12", "--add-reviewer", "@copilot"], result()),
+    exact(
+      [
+        "gh",
+        "api",
+        "--paginate",
+        "--slurp",
+        "repos/{owner}/{repo}/pulls/12/comments",
+      ],
+      result("[[]]\n"),
+    ),
+  ]);
+
+  const workflow = await runPromptWorkflow("Update docs", {
+    shell,
+    logger: new TestLogger(),
+    harness: stubHarness(),
+    sleep: async () => undefined,
+  });
+
+  expect(workflow.committed).toBe(true);
+  expect(workflow.pr?.number).toBe(12);
+  shell.assertComplete();
+});
+
 test("review loop terminates when review fixes produce no file changes", async () => {
   const shell = new SequenceShellRunner([
     exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
     exact(["git", "rev-parse", "--abbrev-ref", "HEAD"], result("main\n")),
-    exact(["git", "status", "--porcelain"], result("")),
+    exact(gitStatusExcludingHarness, result("")),
     codexOutputContains(
       "Return only a git branch name.",
       "feature/review-pass\n",
@@ -274,8 +395,8 @@ test("review loop terminates when review fixes produce no file changes", async (
     ),
     exact(["git", "checkout", "-b", "feature/review-pass", "main"], result()),
     codexEditContains("Implement the requested change in this repository."),
-    exact(["git", "status", "--porcelain"], result(" M src/index.ts\n")),
-    exact(["git", "add", "--all"], result()),
+    exact(gitStatusExcludingHarness, result(" M src/index.ts\n")),
+    exact(gitAddExcludingHarness, result()),
     exact(
       ["git", "diff", "--cached", "--stat"],
       result(" src/index.ts | 2 +-\n"),
@@ -356,7 +477,7 @@ test("review loop terminates when review fixes produce no file changes", async (
     codexEditContains(
       "Review the new pull request review comments and address only valid issues.",
     ),
-    exact(["git", "status", "--porcelain"], result("")),
+    exact(gitStatusExcludingHarness, result("")),
   ]);
 
   const workflow = await runPromptWorkflow("Implement something", {
@@ -380,7 +501,7 @@ test("review loop respects max unproductive polls before exiting", async () => {
   const shell = new SequenceShellRunner([
     exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
     exact(["git", "rev-parse", "--abbrev-ref", "HEAD"], result("main\n")),
-    exact(["git", "status", "--porcelain"], result("")),
+    exact(gitStatusExcludingHarness, result("")),
     codexOutputContains(
       "Return only a git branch name.",
       "feature/review-wait\n",
@@ -391,8 +512,8 @@ test("review loop respects max unproductive polls before exiting", async () => {
     ),
     exact(["git", "checkout", "-b", "feature/review-wait", "main"], result()),
     codexEditContains("Implement the requested change in this repository."),
-    exact(["git", "status", "--porcelain"], result(" M src/index.ts\n")),
-    exact(["git", "add", "--all"], result()),
+    exact(gitStatusExcludingHarness, result(" M src/index.ts\n")),
+    exact(gitAddExcludingHarness, result()),
     exact(
       ["git", "diff", "--cached", "--stat"],
       result(" src/index.ts | 2 +-\n"),
@@ -498,7 +619,7 @@ test("handles only new actionable review comments and re-requests review after p
   const shell = new SequenceShellRunner([
     exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
     exact(["git", "rev-parse", "--abbrev-ref", "HEAD"], result("main\n")),
-    exact(["git", "status", "--porcelain"], result("")),
+    exact(gitStatusExcludingHarness, result("")),
     codexOutputContains(
       "Return only a git branch name.",
       "feature/review-loop\n",
@@ -509,8 +630,8 @@ test("handles only new actionable review comments and re-requests review after p
     ),
     exact(["git", "checkout", "-b", "feature/review-loop", "main"], result()),
     codexEditContains("Implement the requested change in this repository."),
-    exact(["git", "status", "--porcelain"], result(" M src/index.ts\n")),
-    exact(["git", "add", "--all"], result()),
+    exact(gitStatusExcludingHarness, result(" M src/index.ts\n")),
+    exact(gitAddExcludingHarness, result()),
     exact(
       ["git", "diff", "--cached", "--stat"],
       result(" src/index.ts | 2 +-\n"),
@@ -593,8 +714,8 @@ test("handles only new actionable review comments and re-requests review after p
         reviewPrompts.push(spec.args.at(-1) ?? "");
       },
     ),
-    exact(["git", "status", "--porcelain"], result(" M src/workflow.ts\n")),
-    exact(["git", "add", "--all"], result()),
+    exact(gitStatusExcludingHarness, result(" M src/workflow.ts\n")),
+    exact(gitAddExcludingHarness, result()),
     exact(
       ["git", "diff", "--cached", "--stat"],
       result(" src/workflow.ts | 4 ++--\n"),
@@ -646,7 +767,7 @@ test("handles only new actionable review comments and re-requests review after p
         reviewPrompts.push(spec.args.at(-1) ?? "");
       },
     ),
-    exact(["git", "status", "--porcelain"], result("")),
+    exact(gitStatusExcludingHarness, result("")),
   ]);
 
   const workflow = await runPromptWorkflow("Implement something bigger", {


### PR DESCRIPTION
## Summary
- exclude harness-owned `.agc` paths from workspace cleanliness checks and automated staging
- add workflow tests covering `.agc` no-op handling and staging behavior
- document the updated bootstrap and staging behavior in the README

Closes #11.

## Validation
- bun run check
- bun run typecheck
- bun test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude harness-owned `.agc` from the workflow’s Git state so clean checks don’t fail and harness files aren’t accidentally committed. Updates tests and docs to reflect the new behavior.

- **Bug Fixes**
  - Clean workspace and no-op checks now use `git status --porcelain -- . ':(exclude).agc'`.
  - Staging excludes harness files with `git add --all -- . ':(exclude).agc'`.
  - Added workflow tests for `.agc` no-op and staging; updated README to clarify when to commit `.agc/config.json`.

<sup>Written for commit 01bfe603848095c42e084440aa9dbeff544cd53f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated workflow documentation to clarify how the automated system handles harness-owned directory exclusions during clean-workspace checks and PR staging.

* **Improvements**
  * The automated workflow now explicitly excludes harness-owned files during workspace validation, change detection, and repository staging—preventing unnecessary PR commits when only internal state changes are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->