### PR TITLE
fix: only treat ENOENT as missing for harness config reads

### DIFF
--- a/src/harness.test.ts
+++ b/src/harness.test.ts
@@ -85,3 +85,23 @@ test("rejects blank reviewer values in .agc config", async () => {
     /Invalid \.agc\/config\.json:.*Too small: expected string to have >=1 characters/s,
   );
 });
+
+test("surfaces non-ENOENT config read failures", async () => {
+  const repoRoot = await createRepositoryRoot();
+  const readError = Object.assign(new Error("permission denied"), {
+    code: "EACCES",
+  });
+  let writeAttempted = false;
+  const workspace = new FileSystemHarnessWorkspace({
+    mkdir,
+    readFile: async () => {
+      throw readError;
+    },
+    writeFile: async () => {
+      writeAttempted = true;
+    },
+  });
+
+  await expect(workspace.ensure(repoRoot)).rejects.toBe(readError);
+  expect(writeAttempted).toBeFalse();
+});

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -4,6 +4,12 @@ import { z } from "zod";
 import { AppError } from "./errors";
 import type { HarnessConfig } from "./types";
 
+interface HarnessFileSystem {
+  mkdir: typeof mkdir;
+  readFile: typeof readFile;
+  writeFile: typeof writeFile;
+}
+
 export interface HarnessLayout {
   rootDir: string;
   stateDir: string;
@@ -36,6 +42,10 @@ function defaultLayout(repoRoot: string): HarnessLayout {
   };
 }
 
+function isMissingFileError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
 function normalizeConfig(value: unknown): HarnessConfig {
   const parsed = harnessConfigSchema.safeParse(value);
 
@@ -50,11 +60,24 @@ function normalizeConfig(value: unknown): HarnessConfig {
   };
 }
 
-async function ensureConfigFile(path: string): Promise<HarnessConfig> {
-  const existing = await readFile(path, "utf8").catch(() => null);
+async function ensureConfigFile(
+  path: string,
+  fileSystem: Pick<HarnessFileSystem, "readFile" | "writeFile">,
+): Promise<HarnessConfig> {
+  let existing: string | null;
+
+  try {
+    existing = await fileSystem.readFile(path, "utf8");
+  } catch (error) {
+    if (!isMissingFileError(error)) {
+      throw error;
+    }
+
+    existing = null;
+  }
 
   if (existing === null) {
-    await writeFile(
+    await fileSystem.writeFile(
       path,
       `${JSON.stringify(DEFAULT_CONFIG, null, 2)}\n`,
       "utf8",
@@ -83,11 +106,19 @@ export async function createHarnessTempDirectory(
 }
 
 export class FileSystemHarnessWorkspace {
+  constructor(
+    private readonly fileSystem: HarnessFileSystem = {
+      mkdir,
+      readFile,
+      writeFile,
+    },
+  ) {}
+
   async ensure(repoRoot: string): Promise<HarnessWorkspaceState> {
     const layout = defaultLayout(repoRoot);
 
-    await mkdir(layout.stateDir, { recursive: true });
-    const config = await ensureConfigFile(layout.configFile);
+    await this.fileSystem.mkdir(layout.stateDir, { recursive: true });
+    const config = await ensureConfigFile(layout.configFile, this.fileSystem);
 
     return {
       ...layout,


### PR DESCRIPTION
## Summary
- only treat ENOENT as the missing-config case when reading .agc/config.json
- rethrow other filesystem read errors instead of falling back to default config creation
- add regression coverage for non-ENOENT read failures

Closes #10

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat only ENOENT as a missing `.agc/config.json`; other read errors now bubble up instead of creating a default file. Prevents hidden failures and unintended overwrites. Closes #10.

- **Bug Fixes**
  - Handle only `ENOENT` as missing; rethrow other fs errors (e.g., `EACCES`).
  - Do not write a default config when reads fail for non-ENOENT errors.
  - Inject filesystem into `FileSystemHarnessWorkspace`/`ensureConfigFile` and add a regression test to verify error surfacing and no write on failure.

<sup>Written for commit 41cf84cdd672b06feec789d80dfa43baf40f44c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

