### PR TITLE
docs: document Bun.spawn shell runner decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,19 @@ The CLI includes code-driven fallbacks for the helper text generation steps:
 
 If Codex helper calls fail for those bounded text tasks, the workflow still proceeds.
 
+## Process Execution Design
+
+The CLI intentionally keeps subprocess execution behind the `ShellRunner` abstraction in [`src/shell.ts`](./src/shell.ts) and currently implements it with `Bun.spawn`, not `Bun.$`.
+
+That choice is deliberate:
+
+- the workflow already builds exact argv arrays for `git`, `gh`, and `codex`, so `Bun.spawn` maps directly onto the command model we use
+- per-command `cwd`, `env`, optional stdin, separate stdout/stderr capture, and explicit non-zero exit handling are all first-class in the current runner
+- tests can replace `ShellRunner` with a simple fake that asserts exact command arguments and ordering without parsing shell strings
+- `Bun.$` is useful when the shell language itself is the abstraction, but it adds a shell-style composition layer plus mutable global defaults like `$.cwd()` and `$.env()` that this CLI does not need
+
+Based on the Bun 1.3.11 docs and the current codebase shape, migrating this project to `Bun.$` would not materially simplify the implementation. It would mostly translate an argv-based runner into shell syntax, while making command construction and test seams less direct. Revisit the decision only if the CLI starts needing pipelines, redirection-heavy commands, or multi-command shell scripts that are awkward to express with `Bun.spawn`.
+
 ## Major Failure Conditions
 
 The CLI exits non-zero when:

--- a/src/shell.test.ts
+++ b/src/shell.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { CommandExecutionError } from "./errors";
+import { BunShellRunner } from "./shell";
+
+describe("BunShellRunner", () => {
+  test("captures stdout and stderr", async () => {
+    const shell = new BunShellRunner();
+
+    const result = await shell.run({
+      args: ["bun", "-e", "console.log('out'); console.error('err');"],
+    });
+
+    expect(result).toEqual({
+      stdout: "out\n",
+      stderr: "err\n",
+      exitCode: 0,
+    });
+  });
+
+  test("forwards cwd, env, and stdin", async () => {
+    const shell = new BunShellRunner();
+    const cwd = await mkdtemp(join(tmpdir(), "agc-shell-test-"));
+
+    try {
+      const result = await shell.run({
+        args: [
+          "bun",
+          "-e",
+          [
+            "const input = await new Response(Bun.stdin.stream()).text();",
+            "console.log(JSON.stringify({ cwd: process.cwd(), foo: process.env.FOO ?? null, input }));",
+          ].join(" "),
+        ],
+        cwd,
+        env: {
+          FOO: "bar",
+        },
+        input: "hello from stdin",
+      });
+
+      expect(JSON.parse(result.stdout)).toEqual({
+        cwd,
+        foo: "bar",
+        input: "hello from stdin",
+      });
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test("throws on non-zero exit without allowFailure", async () => {
+    const shell = new BunShellRunner();
+
+    await expect(
+      shell.run({
+        args: ["bun", "-e", "console.error('boom'); process.exit(7);"],
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({
+        command: ["bun", "-e", "console.error('boom'); process.exit(7);"],
+        result: {
+          stdout: "",
+          stderr: "boom\n",
+          exitCode: 7,
+        },
+      }),
+    );
+  });
+
+  test("returns non-zero exit results when allowFailure is enabled", async () => {
+    const shell = new BunShellRunner();
+
+    const result = await shell.run({
+      args: ["bun", "-e", "console.error('boom'); process.exit(7);"],
+      allowFailure: true,
+    });
+
+    expect(result).toEqual({
+      stdout: "",
+      stderr: "boom\n",
+      exitCode: 7,
+    });
+  });
+});

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -16,6 +16,8 @@ export class BunShellRunner implements ShellRunner {
     let processHandle: Bun.Subprocess<"pipe", "pipe", "pipe">;
 
     try {
+      // Keep process execution argv-based and per-call. Bun.$ would add a
+      // shell-language layer plus global mutable defaults we do not need here.
       processHandle = Bun.spawn({
         cmd: spec.args,
         cwd: spec.cwd,


### PR DESCRIPTION
## Summary
- document why this CLI should keep using the argv-based ShellRunner on top of Bun.spawn instead of migrating to Bun.$
- add BunShellRunner tests for stdout/stderr capture, cwd/env/stdin forwarding, and non-zero exit handling
- leave a short code comment in the runner to keep the design intent local to the implementation

Closes #12

## Verification
- bun run check
- bun typecheck
- bun test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the decision to keep an argv-based `ShellRunner` on `Bun.spawn` instead of `Bun.$`, and added tests to lock down runner behavior. Tests cover stdout/stderr capture, per-call `cwd`/`env` and stdin forwarding, and non-zero exit handling; a short comment in `BunShellRunner` records the intent.

<sup>Written for commit 5705ffd8974aaf8c55f54c55d4e26f668fb1a63e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Process Execution Design" section documenting subprocess execution abstraction, supported command types, environment configuration, and implementation considerations.

* **Tests**
  * Added comprehensive test suite for shell runner functionality, verifying output capture, error handling, environment variables, and exit codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->