### PR TITLE
feat: rename CLI command to agc

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 It is designed to be executed inside an existing Git repository with a single quoted prompt:
 
 ```bash
-deer-agent "add a regression test for the PR review loop"
+agc "add a regression test for the PR review loop"
 ```
 
 The Bun CLI stays in control of the workflow and uses Codex only for bounded subtasks such as branch naming, implementation, commit text, PR text, and review-fix passes.
@@ -59,7 +59,7 @@ bun start -- "implement the requested change"
 The CLI currently accepts the required prompt argument plus an optional review-loop control flag:
 
 ```bash
-deer-agent --max-unproductive-polls 3 "implement the requested change"
+agc --max-unproductive-polls 3 "implement the requested change"
 ```
 
 `--max-unproductive-polls` controls how many consecutive review polls with no new actionable comments are allowed before the process exits.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Deterministic Bun CLI harness for Git, GitHub CLI, and Codex CLI.",
   "module": "src/index.ts",
   "bin": {
-    "deer-agent": "./src/index.ts"
+    "agc": "./src/index.ts"
   },
   "type": "module",
   "preferGlobal": true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { runPromptWorkflow } from "./workflow";
 const program = new Command();
 
 program
-  .name("deer-agent")
+  .name("agc")
   .description(
     "Deterministic Bun CLI harness for Git, GitHub CLI, and Codex CLI.",
   )


### PR DESCRIPTION
## Summary
- rename the published CLI binary from deer-agent to agc
- update the Commander program name so generated help uses agc
- refresh README usage examples to document the new invocation name

## Verification
- bun run check
- bun typecheck
- bun test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the CLI from `deer-agent` to `agc`. Updated the bin mapping, program name in Commander, and README examples.

- **Migration**
  - Replace `deer-agent` with `agc` in scripts and commands.
  - If installed globally, reinstall to register the new binary.

<sup>Written for commit 215e08c3fd5a3281caf23526286abc41bdd2ea2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI command name from `deer-agent` to `agc` across documentation and application configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->