### PR TITLE
style: use it in Bun tests

### DIFF
--- a/src/harness.test.ts
+++ b/src/harness.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, test } from "bun:test";
+import { afterEach, expect, it } from "bun:test";
 import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -21,7 +21,7 @@ async function createRepositoryRoot(): Promise<string> {
   return root;
 }
 
-test("creates a default .agc layout and config", async () => {
+it("creates a default .agc layout and config", async () => {
   const repoRoot = await createRepositoryRoot();
   const workspace = new FileSystemHarnessWorkspace();
 
@@ -37,7 +37,7 @@ test("creates a default .agc layout and config", async () => {
   });
 });
 
-test("reuses existing .agc reviewer configuration", async () => {
+it("reuses existing .agc reviewer configuration", async () => {
   const repoRoot = await createRepositoryRoot();
   const workspace = new FileSystemHarnessWorkspace();
   const configFile = join(repoRoot, ".agc", "config.json");
@@ -67,7 +67,7 @@ test("reuses existing .agc reviewer configuration", async () => {
   ]);
 });
 
-test("requires trusted review commenters in .agc config", async () => {
+it("requires trusted review commenters in .agc config", async () => {
   const repoRoot = await createRepositoryRoot();
   const workspace = new FileSystemHarnessWorkspace();
   const configFile = join(repoRoot, ".agc", "config.json");
@@ -83,7 +83,7 @@ test("requires trusted review commenters in .agc config", async () => {
   );
 });
 
-test("rejects non-string reviewer values in .agc config", async () => {
+it("rejects non-string reviewer values in .agc config", async () => {
   const repoRoot = await createRepositoryRoot();
   const workspace = new FileSystemHarnessWorkspace();
   const configFile = join(repoRoot, ".agc", "config.json");
@@ -99,7 +99,7 @@ test("rejects non-string reviewer values in .agc config", async () => {
   );
 });
 
-test("rejects blank reviewer values in .agc config", async () => {
+it("rejects blank reviewer values in .agc config", async () => {
   const repoRoot = await createRepositoryRoot();
   const workspace = new FileSystemHarnessWorkspace();
   const configFile = join(repoRoot, ".agc", "config.json");
@@ -115,7 +115,7 @@ test("rejects blank reviewer values in .agc config", async () => {
   );
 });
 
-test("rejects an empty trusted review commenter allowlist", async () => {
+it("rejects an empty trusted review commenter allowlist", async () => {
   const repoRoot = await createRepositoryRoot();
   const workspace = new FileSystemHarnessWorkspace();
   const configFile = join(repoRoot, ".agc", "config.json");
@@ -138,7 +138,7 @@ test("rejects an empty trusted review commenter allowlist", async () => {
   );
 });
 
-test("surfaces non-ENOENT config read failures", async () => {
+it("surfaces non-ENOENT config read failures", async () => {
   const repoRoot = await createRepositoryRoot();
   const readError = Object.assign(new Error("permission denied"), {
     code: "EACCES",

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -183,7 +183,7 @@ afterEach(async () => {
 });
 
 describe("workflow guards", () => {
-  test("fails on dirty workspace", async () => {
+  it("fails on dirty workspace", async () => {
     const shell = new SequenceShellRunner([
       exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
       exact(["git", "rev-parse", "--abbrev-ref", "HEAD"], result("main\n")),
@@ -204,7 +204,7 @@ describe("workflow guards", () => {
     shell.assertComplete();
   });
 
-  test("fails when current branch is not main or master", async () => {
+  it("fails when current branch is not main or master", async () => {
     const shell = new SequenceShellRunner([
       exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
       exact(
@@ -229,7 +229,7 @@ describe("workflow guards", () => {
     shell.assertComplete();
   });
 
-  test("ignores harness-owned .agc changes during workspace guard and no-op detection", async () => {
+  it("ignores harness-owned .agc changes during workspace guard and no-op detection", async () => {
     const shell = new SequenceShellRunner([
       exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
       exact(["git", "rev-parse", "--abbrev-ref", "HEAD"], result("main\n")),
@@ -255,7 +255,7 @@ describe("workflow guards", () => {
   });
 });
 
-test("feature branch naming falls back deterministically", async () => {
+it("feature branch naming falls back deterministically", async () => {
   const shell = new SequenceShellRunner([
     codexOutputContains("Return only a git branch name.", ""),
   ]);
@@ -272,7 +272,7 @@ test("feature branch naming falls back deterministically", async () => {
   shell.assertComplete();
 });
 
-test("commit message generation falls back when codex output is blank", async () => {
+it("commit message generation falls back when codex output is blank", async () => {
   const shell = new SequenceShellRunner([
     codexOutputContains(
       "Return only a single conventional commit message line.",
@@ -295,7 +295,7 @@ test("commit message generation falls back when codex output is blank", async ()
   shell.assertComplete();
 });
 
-test("pull request draft generation falls back when codex output is invalid", async () => {
+it("pull request draft generation falls back when codex output is invalid", async () => {
   const shell = new SequenceShellRunner([
     codexOutputContains(
       "Draft a GitHub pull request title and body.",
@@ -330,7 +330,7 @@ test("pull request draft generation falls back when codex output is invalid", as
   shell.assertComplete();
 });
 
-test("skips commit and PR creation when codex makes no changes", async () => {
+it("skips commit and PR creation when codex makes no changes", async () => {
   const shell = new SequenceShellRunner([
     exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
     exact(["git", "rev-parse", "--abbrev-ref", "HEAD"], result("main\n")),
@@ -367,7 +367,7 @@ test("skips commit and PR creation when codex makes no changes", async () => {
   shell.assertComplete();
 });
 
-test("stages repository changes while excluding harness-owned .agc paths", async () => {
+it("stages repository changes while excluding harness-owned .agc paths", async () => {
   const shell = new SequenceShellRunner([
     exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
     exact(["git", "rev-parse", "--abbrev-ref", "HEAD"], result("main\n")),
@@ -447,7 +447,7 @@ test("stages repository changes while excluding harness-owned .agc paths", async
   shell.assertComplete();
 });
 
-test("review loop terminates when review fixes produce no file changes", async () => {
+it("review loop terminates when review fixes produce no file changes", async () => {
   const shell = new SequenceShellRunner([
     exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
     exact(["git", "rev-parse", "--abbrev-ref", "HEAD"], result("main\n")),
@@ -567,7 +567,7 @@ test("review loop terminates when review fixes produce no file changes", async (
   shell.assertComplete();
 });
 
-test("review loop respects max unproductive polls before exiting", async () => {
+it("review loop respects max unproductive polls before exiting", async () => {
   const shell = new SequenceShellRunner([
     exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
     exact(["git", "rev-parse", "--abbrev-ref", "HEAD"], result("main\n")),
@@ -684,7 +684,7 @@ test("review loop respects max unproductive polls before exiting", async () => {
   shell.assertComplete();
 });
 
-test("ignores untrusted review comments without marking them handled", async () => {
+it("ignores untrusted review comments without marking them handled", async () => {
   const reviewPrompts: string[] = [];
   const logger = new TestLogger();
   const shell = new SequenceShellRunner([
@@ -855,7 +855,7 @@ test("ignores untrusted review comments without marking them handled", async () 
   shell.assertComplete();
 });
 
-test("handles only new actionable review comments and re-requests review after pushed fixes", async () => {
+it("handles only new actionable review comments and re-requests review after pushed fixes", async () => {
   const reviewPrompts: string[] = [];
   const shell = new SequenceShellRunner([
     exact(["git", "rev-parse", "--show-toplevel"], result("/repo\n")),
@@ -1045,7 +1045,7 @@ test("handles only new actionable review comments and re-requests review after p
   shell.assertComplete();
 });
 
-test("console logger emits structured JSON lines", () => {
+it("console logger emits structured JSON lines", () => {
   const logger = new ConsoleLogger();
 
   expect(() => logger.info("test.event", { ok: true })).not.toThrow();


### PR DESCRIPTION
## Summary
- replace direct Bun test API usage from \ to \ in the existing test files
- keep test semantics unchanged while making the suite idiomatic and consistent

## Verification
- bun run check
- bun typecheck
- bun test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched Bun tests to use `it` from `bun:test` instead of `test` for a consistent, idiomatic BDD style. No behavior changes; assertions and test semantics remain the same.

<sup>Written for commit d5ba6654dcfb3ea04dc1e3f5e1c9d0e20c235c22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

