### PR TITLE
refactor: share GitClient git helpers

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -2,6 +2,19 @@ import { describe, expect, it } from "bun:test";
 import { AppError } from "./errors";
 import { GitClient } from "./git";
 import { StubShellRunner, result } from "./test-helpers";
+import type { CommandResult } from "./types";
+
+type GitClientRunGitAccessor = {
+  runGit: (
+    cwd: string,
+    args: string[],
+    options?: {
+      env?: Record<string, string>;
+      input?: string;
+      allowFailure?: boolean;
+    },
+  ) => Promise<CommandResult>;
+};
 
 describe("GitClient workspace status", () => {
   it("ignores harness paths when checking for a clean workspace", async () => {
@@ -41,6 +54,30 @@ describe("GitClient workspace status", () => {
 });
 
 describe("GitClient git command helpers", () => {
+  it("forwards command options through the shared git runner", async () => {
+    const shell = new StubShellRunner([result("ok")]);
+    const git = new GitClient(shell);
+    const privateGit = git as unknown as GitClientRunGitAccessor;
+
+    await expect(
+      privateGit.runGit("/repo", ["status", "--short"], {
+        env: { FOO: "bar" },
+        input: "data",
+        allowFailure: true,
+      }),
+    ).resolves.toEqual(result("ok"));
+
+    expect(shell.calls).toEqual([
+      {
+        args: ["git", "status", "--short"],
+        cwd: "/repo",
+        env: { FOO: "bar" },
+        input: "data",
+        allowFailure: true,
+      },
+    ]);
+  });
+
   it("prefixes standard commands through the shared git runner", async () => {
     const shell = new StubShellRunner([
       result(" /repo \n"),

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,7 +1,6 @@
 import { isAbsolute, resolve } from "node:path";
 import { AppError } from "./errors";
-import type { CommandSpec } from "./types";
-import type { ShellRunner } from "./types";
+import type { CommandSpec, ShellRunner } from "./types";
 
 const HARNESS_GIT_PATHS = [".agc"];
 
@@ -24,7 +23,7 @@ export class GitClient {
     cwd: string,
     args: string[],
     options?: Omit<CommandSpec, "args" | "cwd">,
-  ) {
+  ): ReturnType<ShellRunner["run"]> {
     return this.shell.run({
       ...options,
       args: ["git", ...args],


### PR DESCRIPTION
## Summary
- add a shared `runGit` helper to centralize `git` shell invocations in `GitClient`
- share workspace status retrieval between `ensureCleanWorkspace` and `hasChanges`
- add focused `GitClient` unit tests that pin the common git command shapes

## Verification
- `bun run check`
- `bun typecheck`
- `bun test`

Closes #25

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized all Git invocations in `GitClient` behind a shared `runGit` helper and unified workspace status logic. This reduces duplication, standardizes command shapes, forwards env/input/allowFailure options, and consistently excludes `.agc` paths.

- **Refactors**
  - Routed branch, diff, stage, commit, push, and path queries through `runGit`; added a shared workspace status helper used by `ensureCleanWorkspace` and `hasChanges`.
  - Expanded tests to pin command args, cwd, options passthrough, and outputs for key helpers.

<sup>Written for commit 15478c09e84459d24c28d5db4fa29a10331bc304. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for git client operations, validating workspace cleanliness detection, change tracking, and correct git command execution with proper argument ordering and scope.

* **Refactor**
  * Improved internal git command handling by centralizing operations with shared helper methods, enhancing code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->