### PR TITLE
chore: tighten tsconfig settings

### DIFF
--- a/tests/harness.test.ts
+++ b/tests/harness.test.ts
@@ -2,7 +2,6 @@ import { afterEach, expect, it } from "bun:test";
 import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { AppError } from "../src/errors";
 import { FileSystemHarnessWorkspace } from "../src/harness";
 
 const temporaryDirectories: string[] = [];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,6 @@
     "target": "ESNext",
     "module": "Preserve",
     "moduleDetection": "force",
-    "jsx": "react-jsx",
-    "allowJs": true,
 
     // Bundler mode
     "moduleResolution": "bundler",
@@ -22,8 +20,8 @@
     "noImplicitOverride": true,
 
     // Some stricter flags (disabled by default)
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "noPropertyAccessFromIndexSignature": false,
 
     // Base path


### PR DESCRIPTION
## Summary
- remove unused `jsx` and `allowJs` compiler options from `tsconfig.json`
- enable `noUnusedLocals` and `noUnusedParameters`
- drop the unused `AppError` import surfaced by the stricter TypeScript settings

## Testing
- `bun run check`
- `bun typecheck`
- `bun test`

Closes #43
Closes #45

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tighten TypeScript: remove unused `jsx`/`allowJs`, enable `noUnusedLocals` and `noUnusedParameters`, and drop the unused `AppError` import in tests flagged by the stricter checks. Addresses #43 and #45 by improving type safety and reducing noise.

<sup>Written for commit 3502ec1e6f25c06aabf4938094ac8bd63ebbc131. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed unused imports from test files.

* **Chores**
  * Updated TypeScript compiler configuration to enforce stricter type checking during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->