### PR TITLE
refactor: remove trivial AppError subclass

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,12 +1,5 @@
 import type { CommandResult } from "./types";
 
-export class AppError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "AppError";
-  }
-}
-
 export class CommandExecutionError extends Error {
   readonly command: string[];
   readonly result: CommandResult;

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,5 +1,4 @@
 import { isAbsolute, resolve } from "node:path";
-import { AppError } from "./errors";
 import type { CommandSpec, ShellRunner } from "./types";
 
 const HARNESS_GIT_PATHS = [".agc"];
@@ -67,7 +66,7 @@ export class GitClient {
 
   async ensureCleanWorkspace(cwd: string): Promise<void> {
     if ((await this.getWorkspaceStatus(cwd)).length > 0) {
-      throw new AppError("Workspace must be clean before running this CLI.");
+      throw new Error("Workspace must be clean before running this CLI.");
     }
   }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,5 +1,4 @@
 import { ZodError, z } from "zod";
-import { AppError } from "./errors";
 import type {
   PullRequestDraft,
   PullRequestInfo,
@@ -69,11 +68,11 @@ function parseGitHubJson<T>(
     return schema.parse(JSON.parse(stdout));
   } catch (error) {
     if (error instanceof SyntaxError) {
-      throw new AppError(`${errorPrefix}: invalid JSON response.`);
+      throw new Error(`${errorPrefix}: invalid JSON response.`);
     }
 
     if (error instanceof ZodError) {
-      throw new AppError(
+      throw new Error(
         `${errorPrefix}: ${z.prettifyError(error).replace(/\s+/g, " ").trim()}`,
       );
     }

--- a/src/harness.ts
+++ b/src/harness.ts
@@ -1,7 +1,6 @@
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { z } from "zod";
-import { AppError } from "./errors";
 import type { HarnessConfig } from "./types";
 
 interface HarnessFileSystem {
@@ -53,7 +52,7 @@ function normalizeConfig(value: unknown): HarnessConfig {
   const parsed = harnessConfigSchema.safeParse(value);
 
   if (!parsed.success) {
-    throw new AppError(
+    throw new Error(
       `Invalid .agc/config.json: ${z.prettifyError(parsed.error)}`,
     );
   }
@@ -94,9 +93,7 @@ async function ensureConfigFile(
   try {
     parsed = JSON.parse(existing);
   } catch {
-    throw new AppError(
-      "Invalid .agc/config.json: file must contain valid JSON.",
-    );
+    throw new Error("Invalid .agc/config.json: file must contain valid JSON.");
   }
 
   return normalizeConfig(parsed);

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,4 +1,4 @@
-import { AppError, CommandExecutionError } from "./errors";
+import { CommandExecutionError } from "./errors";
 import type { CommandResult, CommandSpec, ShellRunner } from "./types";
 
 async function readStream(
@@ -29,7 +29,7 @@ export class BunShellRunner implements ShellRunner {
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      throw new AppError(
+      throw new Error(
         `Failed to start command: ${spec.args.join(" ")}\n${message}`,
       );
     }

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -3,7 +3,6 @@ import {
   ALLOWED_BASE_BRANCHES,
   DEFAULT_REVIEW_POLL_INTERVAL_MS,
 } from "./config";
-import { AppError } from "./errors";
 import { GitClient } from "./git";
 import { GitHubClient } from "./github";
 import type { HarnessWorkspaceState } from "./harness";
@@ -83,7 +82,7 @@ export async function runPromptWorkflow(
   const baseBranch = await git.getCurrentBranch(repoRoot);
 
   if (!ALLOWED_BASE_BRANCHES.has(baseBranch)) {
-    throw new AppError(
+    throw new Error(
       "Current branch must be main or master before running this CLI.",
     );
   }

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "bun:test";
-import { AppError } from "../src/errors";
 import { GitClient } from "../src/git";
 import type { CommandResult } from "../src/types";
 import { StubShellRunner, result } from "./test-helpers";
@@ -34,8 +33,8 @@ describe("GitClient workspace status", () => {
     const shell = new StubShellRunner([result(" M src/git.ts\n")]);
     const git = new GitClient(shell);
 
-    await expect(git.ensureCleanWorkspace("/repo")).rejects.toBeInstanceOf(
-      AppError,
+    await expect(git.ensureCleanWorkspace("/repo")).rejects.toThrow(
+      "Workspace must be clean before running this CLI.",
     );
   });
 

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -66,7 +66,7 @@ describe("GitHubClient.createPullRequest", () => {
     });
   });
 
-  it("throws an AppError when PR payload is invalid", async () => {
+  it("throws when PR payload is invalid", async () => {
     const shell = new StubShellRunner([
       result(),
       result(JSON.stringify({ url: "https://example.com/pr/22" })),
@@ -162,7 +162,7 @@ describe("GitHubClient.listReviewComments", () => {
     ]);
   });
 
-  it("throws an AppError when review comments are malformed", async () => {
+  it("throws when review comments are malformed", async () => {
     const shell = new StubShellRunner([
       result(JSON.stringify([{ id: "bad-id", body: "comment" }])),
     ]);

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -4,7 +4,6 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { CodexClient } from "../src/codex";
-import { AppError } from "../src/errors";
 import type { HarnessWorkspaceState } from "../src/harness";
 import { ConsoleLogger } from "../src/logger";
 import type {
@@ -202,9 +201,7 @@ describe("workflow guards", () => {
         harness: stubHarness(),
         sleep: async () => undefined,
       }),
-    ).rejects.toThrow(
-      new AppError("Workspace must be clean before running this CLI."),
-    );
+    ).rejects.toThrow("Workspace must be clean before running this CLI.");
 
     shell.assertComplete();
   });
@@ -226,9 +223,7 @@ describe("workflow guards", () => {
         sleep: async () => undefined,
       }),
     ).rejects.toThrow(
-      new AppError(
-        "Current branch must be main or master before running this CLI.",
-      ),
+      "Current branch must be main or master before running this CLI.",
     );
 
     shell.assertComplete();


### PR DESCRIPTION
## Summary
- remove the trivial AppError subclass from the shared error module
- replace its call sites with plain Error because the CLI does not distinguish them
- update tests to assert error messages instead of the removed type

Closes #38

## Testing
- bun run check
- bun typecheck
- bun test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies error handling by removing the trivial `AppError` subclass and using standard `Error` throughout. No behavior change; aligns with the requirement in #38.

- **Refactors**
  - Removed `AppError` from the shared errors module.
  - Replaced `AppError` throws with `Error` in git, GitHub, harness, shell, and workflow code.
  - Updated tests to assert error messages instead of error types.

<sup>Written for commit 630f593c720cf302b2c1703ef3955e3ab921870a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized error handling to use built-in error types throughout the application while maintaining consistent error messages and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->