### PR TITLE
fix: tighten shell readStream contract

### DIFF
--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,13 +1,7 @@
 import { CommandExecutionError } from "./errors";
 import type { CommandResult, CommandSpec, ShellRunner } from "./types";
 
-async function readStream(
-  stream: ReadableStream<Uint8Array> | null,
-): Promise<string> {
-  if (!stream) {
-    return "";
-  }
-
+async function readStream(stream: ReadableStream<Uint8Array>): Promise<string> {
   return await new Response(stream).text();
 }
 


### PR DESCRIPTION
## Summary
- validate issue #37 and confirm the nullable readStream guard is unreachable in the current Bun shell runner
- tighten readStream to accept a non-null ReadableStream<Uint8Array>
- remove the dead null branch so the helper matches its only callers

## Validation
- bun run check
- bun typecheck
- bun test

Closes #37

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a non-null ReadableStream<Uint8Array> in the shell readStream helper and remove the dead null branch that never ran in Bun. Simplifies the contract and prevents silent empty output. Closes #37.

<sup>Written for commit 8235849c7f7aba14ebb6a545f34bd79f8efca721. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

