### PR TITLE
refactor: remove redundant sleep wrapper

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,7 +30,3 @@ export function clip(value: string, maxLength: number): string {
 export function stableHash(value: string, length = 8): string {
   return createHash("sha256").update(value).digest("hex").slice(0, length);
 }
-
-export function sleep(ms: number): Promise<void> {
-  return Bun.sleep(ms);
-}

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -15,7 +15,6 @@ import type {
   WorkflowOptions,
   WorkflowResult,
 } from "./types";
-import { sleep as defaultSleep } from "./utils";
 
 export interface WorkflowDependencies {
   shell: ShellRunner;
@@ -71,7 +70,7 @@ export async function runPromptWorkflow(
   const { shell, logger } = dependencies;
   const reviewPollIntervalMs =
     dependencies.reviewPollIntervalMs ?? DEFAULT_REVIEW_POLL_INTERVAL_MS;
-  const sleep = dependencies.sleep ?? defaultSleep;
+  const sleep = dependencies.sleep ?? Bun.sleep;
   const maxUnproductivePolls = dependencies.options?.maxUnproductivePolls ?? 1;
   const git = new GitClient(shell);
   const codex = new CodexClient(shell);


### PR DESCRIPTION
## Summary
- remove the redundant `sleep()` wrapper export from `src/utils.ts`
- use `Bun.sleep` directly as the default workflow sleep dependency

## Verification
- `bun run check`
- `bun typecheck`
- `bun test`

Closes #35

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the redundant `sleep` wrapper in `src/utils.ts`. `runPromptWorkflow` now defaults to `Bun.sleep`, simplifying dependencies and reducing indirection.

<sup>Written for commit 2bcea308cf030561e1533496fc8b0b969c151fbc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal polling delay mechanism in workflow processing to use native runtime sleep instead of a utility wrapper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->