### PR TITLE
[codex] Align package name with repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# @deerdaily/codex-pr-agent
+# @deerdaily/agent-github-codex
 
-`@deerdaily/codex-pr-agent` is a globally installable Bun + TypeScript CLI that runs a deterministic Git workflow around `git`, `gh`, and `codex`.
+`@deerdaily/agent-github-codex` is a globally installable Bun + TypeScript CLI that runs a deterministic Git workflow around `git`, `gh`, and `codex`.
 
 It is designed to be executed inside an existing Git repository with a single quoted prompt:
 
@@ -39,7 +39,7 @@ The implementation was wired against locally verified help output from:
 Global install with Bun:
 
 ```bash
-bun install -g @deerdaily/codex-pr-agent
+bun install -g @deerdaily/agent-github-codex
 ```
 
 Local development install:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@deerdaily/codex-pr-agent",
+  "name": "@deerdaily/agent-github-codex",
   "version": "0.1.0",
   "description": "Deterministic Bun CLI harness for Git, GitHub CLI, and Codex CLI.",
   "module": "src/index.ts",


### PR DESCRIPTION
## Summary
- rename the published npm package to `@deerdaily/agent-github-codex`
- update README package references and install example to match the repository-based package name
- keep the npm scope under `@deerdaily` while aligning the package slug with the git repository name

## Why
The package metadata and README still used `@deerdaily/codex-pr-agent`, which no longer matched the actual repository name.

## Validation
- `bun run check`
- `bun typecheck`
- `bun test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the npm package to `@deerdaily/agent-github-codex` to match the repository name and updated README install examples. Keeps the `@deerdaily` scope; no runtime changes.

- **Migration**
  - Replace `@deerdaily/codex-pr-agent` with `@deerdaily/agent-github-codex` in installs and imports.
  - Global install: `bun install -g @deerdaily/agent-github-codex`.

<sup>Written for commit 539da05b4d46dd8e3a5bc9fbe41d895acd4415fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

