### PR TITLE
[codex] Ignore local .agc state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dist
 
 # Codex local state
 .codex
+.agc/


### PR DESCRIPTION
## Summary
- add `.agc/` to `.gitignore`
- keep local harness state out of the default working tree

## Why
The repository-local `.agc/` directory is used for harness state and should not appear as an untracked change during normal development.

## Validation
- verified `git status` only showed the intended `.gitignore` change before commit
- verified `.agc/` stopped appearing as untracked after the ignore rule was added

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.agc/` to `.gitignore` to ignore local Codex harness state and prevent it from showing as untracked files during development.

<sup>Written for commit c189ac983e5781d4934b73d2a260a90b6b788a77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

