### PR TITLE
[codex] fix ignored .agc staging failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The automated workflow treats `.agc/` as harness-owned state:
 
 - preflight clean-workspace checks ignore `.agc/`
 - no-op detection ignores `.agc/`
-- the workflow's `git add --all` step excludes `.agc/`
+- the workflow stages repository changes first, then unstages `.agc/`
 
 That keeps first-run bootstrap and existing local harness state from blocking normal runs or being swept into automated PR commits. If a repository wants to track `.agc/config.json`, commit that file deliberately outside the automated workflow.
 
@@ -165,7 +165,7 @@ Given a single prompt argument, the CLI runs this sequence:
 8. Create the branch from the current base branch with `git checkout -b <branch> <base>`.
 9. Invoke `codex exec` non-interactively to implement the user request.
 10. If no files changed outside `.agc/`, stop cleanly without committing or opening a PR.
-11. If files changed, stage repository changes with `git add --all -- . ':(exclude).agc'`.
+11. If files changed, stage repository changes with `git add --all -- .`, then unstage `.agc/` with `git reset -- .agc`.
 12. Ask Codex for a one-line commit message and fall back to a deterministic conventional message if needed.
 13. Commit and push the branch.
 14. Ask Codex for a PR title/body and fall back to a deterministic template if needed.

--- a/src/git.ts
+++ b/src/git.ts
@@ -89,10 +89,8 @@ export class GitClient {
   }
 
   async stageAll(cwd: string): Promise<void> {
-    await this.runGit(
-      cwd,
-      withExcludedPaths(["add", "--all"], HARNESS_GIT_PATHS),
-    );
+    await this.runGit(cwd, ["add", "--all", "--", "."]);
+    await this.runGit(cwd, ["reset", "--", ...HARNESS_GIT_PATHS]);
   }
 
   async getStagedDiff(cwd: string): Promise<string> {

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -105,6 +105,7 @@ describe("GitClient git command helpers", () => {
       result(),
       result(),
       result(),
+      result(),
       result(" staged stat \n"),
       result(" branch stat \n"),
       result(),
@@ -153,7 +154,11 @@ describe("GitClient git command helpers", () => {
         cwd: "/repo",
       },
       {
-        args: ["git", "add", "--all", "--", ".", ":(exclude).agc"],
+        args: ["git", "add", "--all", "--", "."],
+        cwd: "/repo",
+      },
+      {
+        args: ["git", "reset", "--", ".agc"],
         cwd: "/repo",
       },
       {

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -26,14 +26,8 @@ const gitStatusExcludingHarness = [
   ".",
   ":(exclude).agc",
 ];
-const gitAddExcludingHarness = [
-  "git",
-  "add",
-  "--all",
-  "--",
-  ".",
-  ":(exclude).agc",
-];
+const gitAddExcludingHarness = ["git", "add", "--all", "--", "."];
+const gitResetHarnessPaths = ["git", "reset", "--", ".agc"];
 
 interface Step {
   match(args: string[]): boolean;
@@ -428,6 +422,7 @@ it("stages repository changes while excluding harness-owned .agc paths", async (
     codexEditContains("Implement the requested change in this repository."),
     exact(gitStatusExcludingHarness, result(" M README.md\n")),
     exact(gitAddExcludingHarness, result()),
+    exact(gitResetHarnessPaths, result()),
     exact(["git", "diff", "--cached", "--stat"], result(" README.md | 2 +-\n")),
     codexOutputContains(
       "Return only a single conventional commit message line.",
@@ -514,6 +509,7 @@ it("review loop terminates when review fixes produce no file changes", async () 
     codexEditContains("Implement the requested change in this repository."),
     exact(gitStatusExcludingHarness, result(" M src/index.ts\n")),
     exact(gitAddExcludingHarness, result()),
+    exact(gitResetHarnessPaths, result()),
     exact(
       ["git", "diff", "--cached", "--stat"],
       result(" src/index.ts | 2 +-\n"),
@@ -634,6 +630,7 @@ it("review loop respects max unproductive polls before exiting", async () => {
     codexEditContains("Implement the requested change in this repository."),
     exact(gitStatusExcludingHarness, result(" M src/index.ts\n")),
     exact(gitAddExcludingHarness, result()),
+    exact(gitResetHarnessPaths, result()),
     exact(
       ["git", "diff", "--cached", "--stat"],
       result(" src/index.ts | 2 +-\n"),
@@ -756,6 +753,7 @@ it("ignores untrusted review comments without marking them handled", async () =>
     codexEditContains("Implement the requested change in this repository."),
     exact(gitStatusExcludingHarness, result(" M src/index.ts\n")),
     exact(gitAddExcludingHarness, result()),
+    exact(gitResetHarnessPaths, result()),
     exact(
       ["git", "diff", "--cached", "--stat"],
       result(" src/index.ts | 2 +-\n"),
@@ -923,6 +921,7 @@ it("handles only new actionable review comments and re-requests review after pus
     codexEditContains("Implement the requested change in this repository."),
     exact(gitStatusExcludingHarness, result(" M src/index.ts\n")),
     exact(gitAddExcludingHarness, result()),
+    exact(gitResetHarnessPaths, result()),
     exact(
       ["git", "diff", "--cached", "--stat"],
       result(" src/index.ts | 2 +-\n"),
@@ -1010,6 +1009,7 @@ it("handles only new actionable review comments and re-requests review after pus
     ),
     exact(gitStatusExcludingHarness, result(" M src/workflow.ts\n")),
     exact(gitAddExcludingHarness, result()),
+    exact(gitResetHarnessPaths, result()),
     exact(
       ["git", "diff", "--cached", "--stat"],
       result(" src/workflow.ts | 4 ++--\n"),


### PR DESCRIPTION
## Summary
- replace the `git add --all -- . ':(exclude).agc'` staging flow with `git add --all -- .` followed by `git reset -- .agc`
- preserve the CLI contract that `.agc/` changes are always ignored for automated commits and clean-worktree checks
- update tests and README to match the new staging behavior

## Why
`git add` can fail when passed an ignored pathspec like `:(exclude).agc`, even when the intent is to exclude that path from staging. In repositories that ignore `.agc/`, that caused the CLI to fail before it could commit unrelated work.

## Impact
The CLI now behaves consistently whether `.agc/` paths are tracked, untracked, or ignored. `.agc/` remains excluded from automated commits without tripping Git's ignored-path validation.

## Validation
- `bun run check`
- `bun typecheck`
- `bun test`
- manual reproduction of the Git flow with `.agc/` ignored:
  - `git add --all -- .`
  - `git reset -- .agc`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes staging failures by replacing excluded-path `git add` with add-all then unstage of `.agc/`. The CLI now consistently ignores `.agc/` for automated commits and clean-worktree checks, even when `.agc/` is ignored in the repo.

- **Bug Fixes**
  - Stage with `git add --all -- .`, then unstage `.agc/` via `git reset -- .agc`.
  - Avoids `git add` errors from ignored pathspecs; no more failures when `.agc/` is ignored.
  - Updated tests and README to reflect the new staging flow.

<sup>Written for commit c0e0601881201a1276557e7ba7d11f70463e7af0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow documentation to reflect changes in file staging and exclusion handling.

* **Refactor**
  * Adjusted file staging workflow process.

* **Tests**
  * Updated test suites to verify staging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->