### PR TITLE
fix: accept nullable review comment lines

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -27,7 +27,7 @@ const reviewCommentPayloadSchema = z.object({
   id: z.number(),
   body: z.string().catch(""),
   path: z.string().optional(),
-  line: z.number().optional(),
+  line: z.number().nullable().optional(),
   user: z
     .object({
       login: z.string(),
@@ -60,10 +60,10 @@ const reviewCommentPagesSchema = z
       id: comment.id,
       body: comment.body,
       path: comment.path,
-      line: comment.line,
+      line: comment.line ?? undefined,
       userLogin: comment.user?.login,
       url: comment.html_url,
-      inReplyToId: comment.in_reply_to_id,
+      inReplyToId: comment.in_reply_to_id ?? undefined,
     })),
   );
 

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -142,7 +142,7 @@ describe("GitHubClient.listReviewComments", () => {
         line: 18,
         userLogin: "reviewer",
         url: "https://example.com/comment/101",
-        inReplyToId: null,
+        inReplyToId: undefined,
       },
       {
         id: 102,
@@ -152,6 +152,35 @@ describe("GitHubClient.listReviewComments", () => {
         userLogin: "reviewer-2",
         url: undefined,
         inReplyToId: 101,
+      },
+    ]);
+  });
+
+  it("accepts null line values in review comment payloads", async () => {
+    const shell = new StubShellRunner([
+      result(
+        JSON.stringify([
+          {
+            id: 104,
+            body: "Context-only comment.",
+            path: "README.md",
+            line: null,
+            user: { login: "reviewer-3" },
+          },
+        ]),
+      ),
+    ]);
+    const github = new GitHubClient(shell);
+
+    await expect(github.listReviewComments("/repo", 22)).resolves.toEqual([
+      {
+        id: 104,
+        body: "Context-only comment.",
+        path: "README.md",
+        line: undefined,
+        userLogin: "reviewer-3",
+        url: undefined,
+        inReplyToId: undefined,
       },
     ]);
   });


### PR DESCRIPTION
## Summary
This fixes the review comment parsing failure described in #66 when GitHub returns `"line": null` for pull request review comments.

## What Changed
- Updated the review comment payload schema in `src/github.ts` to accept nullable `line` values from the GitHub API.
- Normalized nullable `line` and `in_reply_to_id` fields to `undefined` when mapping into the internal `ReviewComment` shape.
- Added a regression test in `tests/github.test.ts` that covers review comments with `line: null`.
- Updated the existing review comment expectation to match the normalized `undefined` value for nullable reply IDs.

## Root Cause
`GitHubClient.listReviewComments()` parses the paginated `gh api --paginate --slurp repos/{owner}/{repo}/pulls/<number>/comments` response with a schema that previously accepted only numeric or omitted `line` values. GitHub can legitimately return `null` for `line`, which caused Zod parsing to fail and aborted the review loop.

## Impact
`agc` now accepts valid GitHub review comment payloads that omit a concrete line number via `null`, while preserving downstream behavior by exposing `undefined` instead of `null` internally.

## Validation
- `bun test tests/github.test.ts`
- `bun run check`
- `bun typecheck`
- `bun test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #66 by accepting `null` review comment `line` values from the GitHub API to prevent parsing failures. Normalizes `null` to `undefined` for consistent internal handling and keeps the review loop running.

- **Bug Fixes**
  - Allow `line: null` in the review comment schema in `src/github.ts`.
  - Normalize `line` and `in_reply_to_id` `null` values to `undefined` in `ReviewComment`.
  - Added a regression test covering `line: null` and updated expectations.

<sup>Written for commit c91ddf0989e89db0119943b200424dc9e6f17626. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved data normalization for GitHub API response handling.

* **Tests**
  * Enhanced test coverage for GitHub review comment processing, including scenarios with missing or null field values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->