### PR TITLE
fix: fold GitHub comment page flattening into schema transforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deerdaily/agent-github-codex",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Deterministic Bun CLI harness for Git, GitHub CLI, and Codex CLI.",
   "module": "src/index.ts",
   "bin": {

--- a/src/github.ts
+++ b/src/github.ts
@@ -51,19 +51,11 @@ const issueCommentPayloadSchema = z.object({
 const reviewCommentPageSchema = z.array(reviewCommentPayloadSchema);
 const issueCommentPageSchema = z.array(issueCommentPayloadSchema);
 
-function flattenSlurpedPages<T>(payload: T[] | T[][]): T[] {
-  const firstItem = payload[0];
-
-  if (Array.isArray(firstItem)) {
-    return (payload as T[][]).flat();
-  }
-
-  return payload as T[];
-}
-
 const reviewCommentPagesSchema = z
-  .union([reviewCommentPageSchema, z.array(reviewCommentPageSchema)])
-  .transform((payload) => flattenSlurpedPages(payload))
+  .union([
+    reviewCommentPageSchema.transform((payload) => payload),
+    z.array(reviewCommentPageSchema).transform((payload) => payload.flat()),
+  ])
   .transform((comments): ReviewComment[] =>
     comments.map((comment) => ({
       id: comment.id,
@@ -77,8 +69,10 @@ const reviewCommentPagesSchema = z
   );
 
 const issueCommentPagesSchema = z
-  .union([issueCommentPageSchema, z.array(issueCommentPageSchema)])
-  .transform((payload) => flattenSlurpedPages(payload))
+  .union([
+    issueCommentPageSchema.transform((payload) => payload),
+    z.array(issueCommentPageSchema).transform((payload) => payload.flat()),
+  ])
   .transform((comments): ReviewComment[] =>
     comments.map((comment) => ({
       id: comment.id,

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -106,7 +106,7 @@ describe("GitHubClient.createPullRequest", () => {
 });
 
 describe("GitHubClient.listReviewComments", () => {
-  it("aggregates review comments with general pull request comments", async () => {
+  it("aggregates slurped review comments with slurped general pull request comments", async () => {
     const shell = new StubShellRunner([
       result(
         JSON.stringify([
@@ -173,6 +173,56 @@ describe("GitHubClient.listReviewComments", () => {
         userLogin: "reviewer-2",
         url: undefined,
         inReplyToId: 101,
+      },
+    ]);
+  });
+
+  it("aggregates single-page review comments with single-page general pull request comments", async () => {
+    const shell = new StubShellRunner([
+      result(
+        JSON.stringify([
+          {
+            id: 201,
+            body: "Please rename this helper.",
+            path: "src/github.ts",
+            line: 44,
+            user: { login: "reviewer-4" },
+            html_url: "https://example.com/comment/201",
+            in_reply_to_id: null,
+          },
+        ]),
+      ),
+      result(
+        JSON.stringify([
+          {
+            id: 200,
+            body: "Add a regression test for this path.",
+            user: { login: "reviewer-5" },
+            html_url: "https://example.com/comment/200",
+          },
+        ]),
+      ),
+    ]);
+    const github = new GitHubClient(shell);
+
+    await expect(github.listReviewComments("/repo", 22)).resolves.toEqual([
+      {
+        id: 200,
+        body: "Add a regression test for this path.",
+        path: undefined,
+        line: undefined,
+        userLogin: "reviewer-5",
+        url: "https://example.com/comment/200",
+        inReplyToId: undefined,
+      },
+      {
+        id: 201,
+        body: "Please rename this helper.",
+        path: "src/github.ts",
+        line: 44,
+        userLogin: "reviewer-4",
+        url: "https://example.com/comment/201",
+        inReplyToId: undefined,
       },
     ]);
   });


### PR DESCRIPTION
## Summary
Closes #76.

This updates GitHub comment parsing to normalize paginated responses directly in the branch-specific Zod transforms instead of using the shared `flattenSlurpedPages` helper.

## Changes
- remove the cast-based `flattenSlurpedPages` helper from `src/github.ts`
- encode normalization in each union branch for both review-comment and issue-comment payloads
- preserve support for both single-page responses and `gh api --slurp --paginate` response shapes
- keep the resulting `ReviewComment[]` output unchanged for callers

## Tests
- add coverage for single-page review comments combined with single-page general PR comments
- keep coverage for slurped review comments combined with slurped general PR comments
- verify parsing behavior still accepts nullable review comment line values

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves GitHub PR comment pagination into branch-specific Zod transforms and adds support for single-page responses (closes #76). Removes `flattenSlurpedPages` while keeping the `ReviewComment[]` output and API unchanged.

- **Bug Fixes**
  - Correctly parse both `gh api --slurp --paginate` arrays and single-page arrays for review and general PR comments.
  - Add tests for single-page/slurped combinations and nullable line values.

- **Refactors**
  - Fold page normalization into each union branch via `.transform(...flat())`; delete `flattenSlurpedPages`.
  - Bump package version to 0.2.0.

<sup>Written for commit fc79124bde0516bd10a4bb3de3d91c5f585b57bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.2.0.

* **Refactor**
  * Simplified internal comment handling logic for improved maintainability.

* **Tests**
  * Enhanced test coverage for comment aggregation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->