### PR TITLE
fix(cli): validate max-unproductive-polls with Zod

### DIFF
--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -1,17 +1,34 @@
 import { z } from "zod";
+import { formatZodError } from "./zod-utils";
 
+const maxUnproductivePollsErrorMessage =
+  "--max-unproductive-polls must be a non-negative integer";
 const maxUnproductivePollsSchema = z
   .string()
-  .regex(/^(0|[1-9]\d*)$/, {
-    error: "--max-unproductive-polls must be a non-negative integer",
+  .trim()
+  .regex(/^\d+$/, {
+    message: maxUnproductivePollsErrorMessage,
   })
-  .transform((value) => Number.parseInt(value, 10));
+  .transform((value, context) => {
+    const parsed = BigInt(value);
+
+    if (parsed > BigInt(Number.MAX_SAFE_INTEGER)) {
+      context.addIssue({
+        code: "custom",
+        message: maxUnproductivePollsErrorMessage,
+      });
+
+      return z.NEVER;
+    }
+
+    return Number(parsed);
+  });
 
 export function parseMaxUnproductivePolls(value: string): number {
   const parsed = maxUnproductivePollsSchema.safeParse(value);
 
   if (!parsed.success) {
-    throw new Error("--max-unproductive-polls must be a non-negative integer");
+    throw new Error(formatZodError(parsed.error, { singleLine: true }));
   }
 
   return parsed.data;

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+const maxUnproductivePollsSchema = z
+  .string()
+  .regex(/^(0|[1-9]\d*)$/, {
+    error: "--max-unproductive-polls must be a non-negative integer",
+  })
+  .transform((value) => Number.parseInt(value, 10));
+
+export function parseMaxUnproductivePolls(value: string): number {
+  const parsed = maxUnproductivePollsSchema.safeParse(value);
+
+  if (!parsed.success) {
+    throw new Error("--max-unproductive-polls must be a non-negative integer");
+  }
+
+  return parsed.data;
+}

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { formatZodError } from "./zod-utils";
 
 const maxUnproductivePollsErrorMessage =
   "--max-unproductive-polls must be a non-negative integer";
@@ -28,7 +27,9 @@ export function parseMaxUnproductivePolls(value: string): number {
   const parsed = maxUnproductivePollsSchema.safeParse(value);
 
   if (!parsed.success) {
-    throw new Error(formatZodError(parsed.error, { singleLine: true }));
+    throw new Error(
+      parsed.error.issues[0]?.message ?? maxUnproductivePollsErrorMessage,
+    );
   }
 
   return parsed.data;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { Command } from "commander";
+import { parseMaxUnproductivePolls } from "./cli-options";
 import { ConsoleLogger } from "./logger";
 import { BunShellRunner } from "./shell";
 import { readPackageVersion } from "./version";
@@ -16,17 +17,7 @@ program
   .option(
     "--max-unproductive-polls <count>",
     "Number of consecutive review polls with no new actionable comments before exiting; 0 means poll indefinitely",
-    (value: string) => {
-      const parsed = Number.parseInt(value, 10);
-
-      if (!Number.isInteger(parsed) || parsed < 0) {
-        throw new Error(
-          "--max-unproductive-polls must be a non-negative integer",
-        );
-      }
-
-      return parsed;
-    },
+    parseMaxUnproductivePolls,
     1,
   )
   .argument("<prompt>", "Prompt describing the requested repository change")

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -51,6 +51,9 @@ describe("CLI versioning", () => {
 });
 
 describe("parseMaxUnproductivePolls", () => {
+  const maxUnproductivePollsErrorMessage =
+    "--max-unproductive-polls must be a non-negative integer";
+
   it("accepts non-negative integer strings", () => {
     expect(parseMaxUnproductivePolls("0")).toBe(0);
     expect(parseMaxUnproductivePolls("1")).toBe(1);
@@ -61,8 +64,8 @@ describe("parseMaxUnproductivePolls", () => {
 
   it("rejects invalid values with the CLI error message", () => {
     for (const value of ["-1", "1.5", "abc"]) {
-      expect(() => parseMaxUnproductivePolls(value)).toThrow(
-        "--max-unproductive-polls must be a non-negative integer",
+      expect(() => parseMaxUnproductivePolls(value)).toThrowError(
+        new Error(maxUnproductivePollsErrorMessage),
       );
     }
   });
@@ -72,8 +75,8 @@ describe("parseMaxUnproductivePolls", () => {
       "9007199254740992",
       "999999999999999999999999999999999999",
     ]) {
-      expect(() => parseMaxUnproductivePolls(value)).toThrow(
-        "--max-unproductive-polls must be a non-negative integer",
+      expect(() => parseMaxUnproductivePolls(value)).toThrowError(
+        new Error(maxUnproductivePollsErrorMessage),
       );
     }
   });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -55,10 +55,23 @@ describe("parseMaxUnproductivePolls", () => {
     expect(parseMaxUnproductivePolls("0")).toBe(0);
     expect(parseMaxUnproductivePolls("1")).toBe(1);
     expect(parseMaxUnproductivePolls("25")).toBe(25);
+    expect(parseMaxUnproductivePolls("01")).toBe(1);
+    expect(parseMaxUnproductivePolls(" 2 ")).toBe(2);
   });
 
   it("rejects invalid values with the CLI error message", () => {
-    for (const value of ["-1", "1.5", "abc", "01", " 2 "]) {
+    for (const value of ["-1", "1.5", "abc"]) {
+      expect(() => parseMaxUnproductivePolls(value)).toThrow(
+        "--max-unproductive-polls must be a non-negative integer",
+      );
+    }
+  });
+
+  it("rejects values above JavaScript's safe integer range", () => {
+    for (const value of [
+      "9007199254740992",
+      "999999999999999999999999999999999999",
+    ]) {
       expect(() => parseMaxUnproductivePolls(value)).toThrow(
         "--max-unproductive-polls must be a non-negative integer",
       );

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { parseMaxUnproductivePolls } from "../src/cli-options";
 import { readPackageVersion } from "../src/version";
 
 describe("CLI versioning", () => {
@@ -45,6 +46,22 @@ describe("CLI versioning", () => {
       );
     } finally {
       await rm(tempDir, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("parseMaxUnproductivePolls", () => {
+  it("accepts non-negative integer strings", () => {
+    expect(parseMaxUnproductivePolls("0")).toBe(0);
+    expect(parseMaxUnproductivePolls("1")).toBe(1);
+    expect(parseMaxUnproductivePolls("25")).toBe(25);
+  });
+
+  it("rejects invalid values with the CLI error message", () => {
+    for (const value of ["-1", "1.5", "abc", "01", " 2 "]) {
+      expect(() => parseMaxUnproductivePolls(value)).toThrow(
+        "--max-unproductive-polls must be a non-negative integer",
+      );
     }
   });
 });


### PR DESCRIPTION
## Summary
Closes #77.

This replaces the ad hoc `--max-unproductive-polls` parsing in `src/index.ts` with a dedicated Zod-backed parser so CLI option validation follows the same pattern used elsewhere in the codebase.

## Changes
- add `parseMaxUnproductivePolls` in `src/cli-options.ts`
- move `--max-unproductive-polls` validation from inline commander logic to the shared parser
- preserve the existing user-facing error message for invalid values
- add tests covering accepted non-negative integers and rejected invalid inputs

## Testing
- `bun test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `--max-unproductive-polls` with a `zod`-based parser for consistent CLI validation, preserving the existing CLI error message and adding tests. Accepts trimmed non-negative integer strings (e.g., " 2 ", "01"), rejects negatives, non-integers, and values above `Number.MAX_SAFE_INTEGER` (closes #77).

<sup>Written for commit 0088f69297d8c5db71fe235102effce5e83eb093. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced validation for the `--max-unproductive-polls` CLI option with improved error messaging to ensure only non-negative integers are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->